### PR TITLE
Fix NFC HCE on hlte

### DIFF
--- a/configs/libnfc-brcm.conf
+++ b/configs/libnfc-brcm.conf
@@ -293,3 +293,9 @@ AUTO_ADJUST_ISO_BITRATE=1
 
 # NCI Hal Module name
 NCI_HAL_MODULE="nfc_nci.bcm2079x"
+
+###############################################################################
+# Enable/Disable NFC-F HCE
+# Disable       0x00
+# Enable        non-zero value
+ENABLE_NFCF_HCE=0x00


### PR DESCRIPTION
This is my first contact with pull request on GitHub so I hope I'm doing this right.

This is a fix for Tap2Pay for hlte that was implemented originally for oneplus bacon that uses same nfc nci chip.
Link to LA OS change: https://review.lineageos.org/#/c/161917/
I copied the code from klte libnfc-brcm.conf

I'm not 100% sure I got this right, but this should fix HCE issues on hlte without need to replace nfcnci library.